### PR TITLE
Add platforms field for macOS and Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "News"
   ],
   "license": "MIT",
+  "platforms": ["macOS", "Windows"],
   "commands": [
     {
       "name": "nhl-scores-and-schedule",


### PR DESCRIPTION
## Summary
- Adds the `platforms` field to package.json declaring support for both macOS and Windows

## Test plan
- Verify package.json is valid JSON
- Confirm extension loads correctly on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)